### PR TITLE
Configure solenoid IDs

### DIFF
--- a/zebROS_ws/src/climber_controller/src/climber_controller.cpp
+++ b/zebROS_ws/src/climber_controller/src/climber_controller.cpp
@@ -41,7 +41,7 @@ void ClimberController::update(const ros::Time &time, const ros::Duration &perio
 	}
 	else if(feet_retract_cmd == false)
 	{
-		feet_retract_cmd_double = 0;
+		feet_retract_cmd_double = -1;
 	}
 
     feet_retract_.setCommand(feet_retract_cmd_double); // set the in/out command to the clampy part of the climber
@@ -53,7 +53,7 @@ void ClimberController::update(const ros::Time &time, const ros::Duration &perio
 	}
 	else if(release_endgame_cmd == false)
 	{
-		release_endgame_cmd_double = 0;
+		release_endgame_cmd_double = -1;
 	}
 
     release_endgame_.setCommand(release_endgame_cmd_double); // set the in/out command to the clampy part of the climber

--- a/zebROS_ws/src/ros_control_boilerplate/config/2018_compbot_base_jetson.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2018_compbot_base_jetson.yaml
@@ -17,12 +17,12 @@ hardware_interface:
    joints:
        #TODO: Get config values of joints
        - {name: cargo_intake_joint, type: can_talon_srx, can_id: 31, local: true}
-       - {name: cargo_intake_arm_joint, type: solenoid, pcm: 0, id: 2, local_hardware: false, local_update: true}
+       - {name: cargo_intake_arm_joint, type: solenoid, pcm: 0, id: 0, local_hardware: false, local_update: true}
        - {name: cargo_outtake_kicker_joint, type: solenoid, pcm: 0, id: 3, local_hardware: false, local_update: true}
-       - {name: cargo_outtake_clamp_joint, type: solenoid, pcm: 0, id: 4, local_hardware: false, local_update: true}
+       - {name: cargo_outtake_clamp_joint, type: solenoid, pcm: 0, id: 2, local_hardware: false, local_update: true}
 
-       - {name: climber_feet_retract, type: solenoid, pcm: 0, id: 0, local_hardware: false, local_update: true}
-       - {name: climber_release_endgame, type: solenoid, pcm: 0, id: 1, local_hardware: false, local_update: true}
+       - {name: climber_feet_retract, type: double_solenoid, pcm: 0, forward_id: 5, reverse_id: 4, local_hardware: false, local_update: true}
+       - {name: climber_release_endgame, type: double_solenoid, pcm: 0, forward_id: 6, reverse_id: 7, local_hardware: false, local_update: true}
 
        # TODO : figure out how many followers, define them here
        - {name: elevator_master, type: can_talon_srx, can_id: 41, local: true}


### PR DESCRIPTION
PCM channels in 2018_compbot_base_jetson.yaml should be set up right, and climber_controller.cpp set up to handle the double solenoids.