### PR TITLE
Put correct pcm ids in 2019_compbot_base_jetson.yaml

### DIFF
--- a/zebROS_ws/src/ros_control_boilerplate/config/2019_compbot_base_jetson.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2019_compbot_base_jetson.yaml
@@ -17,12 +17,12 @@ hardware_interface:
    joints:
        #TODO: Get config values of joints
        - {name: cargo_intake_joint, type: can_talon_srx, can_id: 31, local: true}
-       - {name: cargo_intake_arm_joint, type: solenoid, pcm: 0, id: 2, local_hardware: false, local_update: true}
+       - {name: cargo_intake_arm_joint, type: solenoid, pcm: 0, id: 0, local_hardware: false, local_update: true}
        - {name: cargo_outtake_kicker_joint, type: solenoid, pcm: 0, id: 3, local_hardware: false, local_update: true}
-       - {name: cargo_outtake_clamp_joint, type: solenoid, pcm: 0, id: 4, local_hardware: false, local_update: true}
+       - {name: cargo_outtake_clamp_joint, type: solenoid, pcm: 0, id: 2, local_hardware: false, local_update: true}
 
-       - {name: climber_feet_retract, type: solenoid, pcm: 0, id: 0, local_hardware: false, local_update: true}
-       - {name: climber_release_endgame, type: solenoid, pcm: 0, id: 1, local_hardware: false, local_update: true}
+       - {name: climber_feet_retract, type: double_solenoid, pcm: 0, forward_id: 5, reverse_id: 4, local_hardware: false, local_update: true}
+       - {name: climber_release_endgame, type: double_solenoid, pcm: 0, forward_id: 6, reverse_id: 7, local_hardware: false, local_update: true}
 
        # TODO : figure out how many followers, define them here
        - {name: elevator_master, type: can_talon_srx, can_id: 41, local: true}


### PR DESCRIPTION
The launch file changed to reference 2019_compbot_base_jetson.yaml in master, but we modified pcm id values in 2018_compbot_base_jetson.yaml because we were previously using that file. Moved pcm ids over.