### PR TITLE
Add talon motion profile arc mode, 

### DIFF
--- a/zebROS_ws/src/talon_interface/include/talon_interface/talon_state_interface.h
+++ b/zebROS_ws/src/talon_interface/include/talon_interface/talon_state_interface.h
@@ -20,6 +20,7 @@ enum TalonMode
 	TalonMode_Follower,
 	TalonMode_MotionProfile,
 	TalonMode_MotionMagic,
+	TalonMode_MotionProfileArc,
 	TalonMode_Disabled,
 	TalonMode_Last
 };

--- a/zebROS_ws/src/talon_state_controller/src/talon_state_controller.cpp
+++ b/zebROS_ws/src/talon_state_controller/src/talon_state_controller.cpp
@@ -411,6 +411,9 @@ void TalonStateController::update(const ros::Time &time, const ros::Duration & /
 					case hardware_interface::TalonMode_MotionMagic:
 						m.talon_mode[i] = "Motion Magic";
 						break;
+					case hardware_interface::TalonMode_MotionProfileArc:
+						m.talon_mode[i] = "Motion Profile Arc";
+						break;
 					case hardware_interface::TalonMode_Disabled:
 						m.talon_mode[i] = "Disabled";
 						break;


### PR DESCRIPTION
This is a new talon mode we didn't previously support in code.

Restrict calls to getActiveTrajectoryHeading to this mode only to suppress error spam about it in other
motion profile modes